### PR TITLE
fix: defer instant trigger handling when keydown has no text

### DIFF
--- a/src/services/expansion-service.ts
+++ b/src/services/expansion-service.ts
@@ -144,46 +144,58 @@ export class ExpansionService {
 				const cursorCharIndex = getCursorCharIndex(afterText, afterCursor);
 				const insertedText = extractInsertedText(afterText, beforeCharIndex, cursorCharIndex);
 				const fallbackFromCursor = getGraphemeBeforeIndex(afterText, cursorCharIndex);
-				const normalizedKey = normalizeTriggerKey(event.key, insertedText, fallbackFromCursor);
-				const anticipatedAction = this.getTriggerActionFromKey(normalizedKey);
-				if (anticipatedAction === 'instant') {
-					this.lastKeyboardInstantTimestamp = performance.now();
-				} else if (anticipatedAction) {
-					this.lastKeyboardInstantTimestamp = null;
-				}
-				if (normalizedKey !== event.key) {
-					log(`Normalized key '${event.key}' to '${normalizedKey}' for instant trigger handling`);
-				}
+                                const normalizedKey = normalizeTriggerKey(event.key, insertedText, fallbackFromCursor);
+                                const anticipatedAction = this.getTriggerActionFromKey(normalizedKey);
+                                const shouldDeferToInput = anticipatedAction === 'instant' && !insertedText && event.key.length === 1;
 
-				const context: TriggerContext = {
-				triggerKey: normalizedKey,
-				originalKey: event.key,
-				insertedText,
-				beforeText,
-				beforeCursor,
-				afterText,
-				afterCursor,
-				cursorCharIndex,
-				deletedChar: null
-			};
+                                if (anticipatedAction === 'instant') {
+                                        if (shouldDeferToInput) {
+                                                this.lastKeyboardInstantTimestamp = null;
+                                        } else {
+                                                this.lastKeyboardInstantTimestamp = performance.now();
+                                        }
+                                } else if (anticipatedAction) {
+                                        this.lastKeyboardInstantTimestamp = null;
+                                }
+                                if (normalizedKey !== event.key) {
+                                        log(`Normalized key '${event.key}' to '${normalizedKey}' for instant trigger handling`);
+                                }
 
-				this.notifyDebug({
-					source: 'keydown',
-					eventKey: event.key,
-					normalizedKey,
-					insertedText,
-					metadata: {
-						anticipatedAction,
-						beforeCharIndex,
-						cursorCharIndex,
-						unreliable: isUnreliableInstantKey(event.key)
-					}
-				});
+                                this.notifyDebug({
+                                        source: 'keydown',
+                                        eventKey: event.key,
+                                        normalizedKey,
+                                        insertedText,
+                                        metadata: {
+                                                anticipatedAction,
+                                                beforeCharIndex,
+                                                cursorCharIndex,
+                                                unreliable: isUnreliableInstantKey(event.key),
+                                                deferredToInput: shouldDeferToInput
+                                        }
+                                });
 
-				callback(context);
-			}, 0);
-		};
-	}
+                                if (shouldDeferToInput) {
+                                        log(`Deferring instant trigger handling to input event for key '${event.key}' (no inserted text yet)`);
+                                        return;
+                                }
+
+                                const context: TriggerContext = {
+                                        triggerKey: normalizedKey,
+                                        originalKey: event.key,
+                                        insertedText,
+                                        beforeText,
+                                        beforeCursor,
+                                        afterText,
+                                        afterCursor,
+                                        cursorCharIndex,
+                                        deletedChar: null
+                                };
+
+                                callback(context);
+                        }, 0);
+                };
+        }
 
 
 	private isInteractionAllowed(


### PR DESCRIPTION
## Summary
- avoid running instant trigger matching on keydown events that don't report inserted characters
- add debug metadata and logs to show when handling is deferred to beforeinput/input events
- rely on input events to supply the correct cursor position so instant expansions work on iOS

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2568466a88329b692dd3828d9334f