### PR TITLE
fix: wait for workspace ready before loading config file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -62,15 +62,17 @@ export default class AutoExpander extends Plugin {
 	/**
 	 * Initialize plugin components and setup
 	 */
-	private async initializePlugin(): Promise<void> {
-		// Load settings
-		this.settings = await this.settingsService.loadSettings();
+        private async initializePlugin(): Promise<void> {
+                // Load settings
+                this.settings = await this.settingsService.loadSettings();
 
-		// Initialize config file service with current path
-		this.configFileService.setConfigFilePath(this.settings.configFilePath);
+                await this.waitForWorkspaceReady();
 
-		// Load and validate snippets from config file
-		await this.loadSnippetsFromConfigFile();
+                // Initialize config file service with current path
+                this.configFileService.setConfigFilePath(this.settings.configFilePath);
+
+                // Load and validate snippets from config file
+                await this.loadSnippetsFromConfigFile();
 
 		// Set initial delays
 		this.expansionService.updateCommandDelay(this.settings.commandDelay);
@@ -88,8 +90,18 @@ export default class AutoExpander extends Plugin {
 		this.setupExpansionMechanism();
 
 		// Register global event listeners
-		this.registerGlobalEvents();
-	}
+                this.registerGlobalEvents();
+        }
+
+        private async waitForWorkspaceReady(): Promise<void> {
+                if (this.app.workspace.layoutReady) {
+                        return;
+                }
+
+                await new Promise<void>((resolve) => {
+                        this.app.workspace.onLayoutReady(() => resolve());
+                });
+        }
 
 	/**
 	 * Load snippets from the config file


### PR DESCRIPTION
## Summary
- wait for the Obsidian workspace layout to be ready before initializing the config file service so saved paths are resolved on startup

## Testing
- npm run lint
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d7d7686514832997b2ed385a4b04cb